### PR TITLE
Swap block margins and page paddings

### DIFF
--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -4,7 +4,7 @@
 @import url(./__lang-link/_type/_ru/header__lang-link_type_ru.css);
 
 .header {
-  margin: 0 48px;
+  margin-bottom: 56px;
   display: flex;
   flex: 1 1 auto;
   flex-wrap: wrap;

--- a/blocks/page/page.css
+++ b/blocks/page/page.css
@@ -1,6 +1,6 @@
 .page {
   margin: 0;
-  padding: 28px 0 24px;
+  padding: 28px 48px 24px;
   display: grid;
   grid-template-columns: minmax(200px, 1fr);
   background-color: #2A2C2F;


### PR DESCRIPTION
There were zero side paddings for the `body` (`page` block) and 48px side margins for `header` section.

Now there are 48px side paddings in `body` and zero side margins in `header`.